### PR TITLE
Fix #134: Empty hook_handlers list in the Extractor

### DIFF
--- a/models/extractor.py
+++ b/models/extractor.py
@@ -53,6 +53,7 @@ class VitExtractor:
     def _clear_hooks(self):
         for handler in self.hook_handlers:
             handler.remove()
+        self.hook_handlers = []
 
     def _get_block_hook(self):
         def _get_block_output(model, input, output):


### PR DESCRIPTION
By emptying the hook handler list, python can remove the hook handlers that are no longer active (but still take up memory). In my test run, the loss keeps decreasing after this change